### PR TITLE
Add inline syntax highlighting

### DIFF
--- a/A_Getting_started/lesson3.rst
+++ b/A_Getting_started/lesson3.rst
@@ -58,14 +58,14 @@ value from the left-hand side of the model tree, the ‘Value’ property of
 Chart View will change accordingly.
 
 It is possible to select and display several properties simultaneously
-in Chart View by using the asterisk (``*``) character. If you double- click
+in Chart View by using the asterisk (:literal:`*`) character. If you double- click
 the ‘Value’ property of your Chart View, it becomes editable. Let us
-edit the last ``Hip_ProximoDistalForce`` term to ``Hip_*``.
+edit the last :literal:`Hip_ProximoDistalForce` term to :literal:`Hip_*`.
 
 |Chart view asterix selection|
 
-Now you will see the ‘Hip\_MediolateralForce’, ‘Hip\_ProximoDistalForce’
-and ‘Hip\_AnteroPosteriorForce’ in the same Chart View.
+Now you will see the ‘Hip_MediolateralForce’, ‘Hip_ProximoDistalForce’
+and ‘Hip_AnteroPosteriorForce’ in the same Chart View.
 
 Hip forces - Bent posture
 -------------------------

--- a/A_Getting_started_anyscript/lesson1.rst
+++ b/A_Getting_started_anyscript/lesson1.rst
@@ -127,7 +127,9 @@ and select “Load Model”.
 
 |Load model right click menu|
 
-You may get a similar message in the Output Window.::
+You may get a similar message in the Output Window.
+
+.. code-block:: none
 
     Loading Main : "C:\\...\\NewModel.main.any"
     Scanning...
@@ -148,10 +150,11 @@ Basic troubleshooting
 If you mistype something, you will get an error message. A common
 mistake is to forget a semicolon somewhere. Try removing the last
 semicolon in the AnyScript file, and load again. You get a message
-saying something like: ::
+saying something like: 
 
-    ERROR(SCR.PRS11) : C:\\...\\NewModel.main.any(26) : 'EOF' unexpected
-    Model loading skipped
+.. code-block:: none
+
+    ERROR(SCR.PRS11) : C:\\...\\NewModel.main.any(26) : 'EOF' unexpected Model loading skipped
 
 First, there is a message ID, then a file location and finally the body
 of the message. The former two are written in blue and underlined to

--- a/A_Getting_started_anyscript/lesson3.rst
+++ b/A_Getting_started_anyscript/lesson3.rst
@@ -240,7 +240,9 @@ line below to obtain this:
 
 
 It seems like everything is connected now. So why do we still get the
-annoying error message when we reload the model?::
+annoying error message when we reload the model?
+
+.. code-block:: none
 
     Model Warning: Study 'Main.ArmStudy' contains too few kinematic
     constraints to be kinematically determinate.

--- a/A_Getting_started_modeling/lesson2.rst
+++ b/A_Getting_started_modeling/lesson2.rst
@@ -58,7 +58,9 @@ including the “HumanModel.any” file.
       #include "<ANYBODY_PATH_BODY>\HumanModel.any"
     
 
-Try loading the model again. F7 should produce the encouraging message:::
+Try loading the model again. F7 should produce the encouraging message:
+
+.. code-block:: none
 
     Model Warning: Study 'Main.Study' contains too few kinematic constraints to be kinematically determinate.
     Evaluating model...

--- a/A_study_of_studies/lesson1.rst
+++ b/A_study_of_studies/lesson1.rst
@@ -207,7 +207,9 @@ it means that the system will obtain enough reaction forces to carry the
 loads without help from any muscles, corresponding to the statically
 determinate situation 2 listed above. Loading the model does not bring
 about any warnings, but if you run the InverseDynamics operation you
-will get the following message for each time-step::
+will get the following message for each time-step
+
+.. code-block:: none
 
     'ArmStudy':  The muscles in the model are not loaded due to kinetically over-constrained mechanical system.
 

--- a/AnyExp4SOLIDWORKS/lesson3.rst
+++ b/AnyExp4SOLIDWORKS/lesson3.rst
@@ -262,7 +262,9 @@ When you load this model, you will see the following warning message:
 
 If you look at the Object Description of your AnyBodyStudy object, you
 can find the information about the number of DOFs and constraints of the
-model.::
+model.
+
+.. code-block:: none
 
     Total number of rigid-body d.o.f.: 360
     Total number of constraints:

--- a/Finite_element_analysis/lesson1.rst
+++ b/Finite_element_analysis/lesson1.rst
@@ -1,3 +1,8 @@
+.. Disable inline anyscript highlighting.
+
+.. highlight:: none
+
+
 Lesson 1: Export of data for FEA
 ================================
 
@@ -18,9 +23,9 @@ tutorial text and your own results please download AMMRV1.6 from
 
 The starting point for this tutorial is the model:
 
-``Applications/Examples/StandingLift/StandingLiftFEA.main.any``
+:file:`Applications/Examples/StandingLift/StandingLiftFEA.main.any`
 
-However, this model internally reuses the code of ``StandingLift.main.any``. Please
+However, this model internally reuses the code of :file:`StandingLift.main.any`. Please
 find the model and load it by pushing F7 and open a Model View. You
 should see something similar to the picture to the right. The vertebral
 body we want to analyze is marked with a circle on the zoomed-in
@@ -95,7 +100,9 @@ Press the “Run” button. The model will analyze one timestep and write
 the FEAoutput.txt file which we have specified before. Let’s have a
 closer look on the Output file. It is located inside your Application
 folder in the Output subfolder. You can open it either directly in
-AnyBody or in any text editor of your choice.::
+AnyBody or in any text editor of your choice.
+
+.. code-block:: none
 
     Environment:
     ReferenceFrame=Global Model Frame;
@@ -166,7 +173,10 @@ default) the global coordinate system or it can be a local coordinate
 system.
 
 Let us have a look at the following entry which basically gives the
-joint constraints in the L5-Sacrum joint:::
+joint constraints in the L5-Sacrum joint:
+
+
+.. code-block:: none
 
   Force[12]:
   Name=Main.HumanModel.BodyModel.Trunk.JointsLumbar.L5SacrumJnt.Constraints.Reaction;
@@ -197,7 +207,7 @@ has not been reloaded since the force export otherwise run the
 InverseDynamicAnalysis again to bring it to right position. Of course
 it also involves all scaling which has been applied to the bones.
 Browse through the model tree to the L5Seg
-(``Main\HumanModel\BodyModel\Trunk\SegmentsLumbar\L5Seg``) in order
+``Main/HumanModel/BodyModel/Trunk.SegmentsLumbar/L5Seg`` in order
 to export the L5 segment. Inside this folder you find the DrawSTL
 folder. Right-click the folder and choose “Export Surface”. Choose a
 convenient place to store the file and give it the name “L5.stl”. A
@@ -331,7 +341,9 @@ After the definition of a node set on both endplates we have to
 provide the boundary conditions. For this we need our force export
 file. Please open the file (it should be located in your
 StandingLiftFEA application folder) in an editor and scroll down to
-Force[12]. This force is the joint reaction on the L5-Sacrum joint.::
+Force[12]. This force is the joint reaction on the L5-Sacrum joint.
+
+.. code-block:: none
 
   Force[12]:
   Name=Main.HumanModel.BodyModel.Trunk.JointsLumbar.L5SacrumJnt.Constraints.Reaction;
@@ -368,7 +380,9 @@ save.
 There is one more thing that has to be defined preliminary to the FEA
 - the desired output. Please open a text editor and load the L5FEA.inp
 file. In this file the whole analysis is defined, using a reference to
-the node and elements file.::
+the node and elements file.
+
+.. code-block:: none
 
   **=========================================================================
   **                          HISTORY DATA                                 **
@@ -416,13 +430,17 @@ If you want to use this model instead of your own build, please change
 the following comments involving”L5FEA” to “L5FEABackup”.)
 
 Open up the Calculix command shell and browse to the directory where
-you placed the L5FEA.inp file. Now type::
+you placed the L5FEA.inp file. Now type
+
+.. code-block:: none
 
   ccx L5FEA
 
 and press return. This will push the model forward to the solver and
 start the analysis. Within a few seconds a nice JOB FINISHED should
-appear. Now, let’s have look at the results: Therefore, type::
+appear. Now, let’s have look at the results: Therefore, type
+
+.. code-block:: none
 
   cgx L5FEA.frd
 

--- a/Finite_element_analysis/lesson2.rst
+++ b/Finite_element_analysis/lesson2.rst
@@ -1,3 +1,7 @@
+.. Disable inline anyscript highlighting.
+
+.. highlight:: none
+
 Lesson 2: ANSYS Interface
 =========================
 
@@ -223,7 +227,9 @@ and a solve command. The file is created in a way that it assumes the
 local coordinate name in which all forces are given is named 1000, and
 the material numbers of implant and fracture are between 50 and 60. The
 template can be altered to fit to your actual problem. One thing you
-have to change right now is the path to your FE model.::
+have to change right now is the path to your FE model.
+
+:: console
 
     RESUME,'clav_base','db','C:\Users\sd.ANYBODY\TEMP\Clavicle_paper\FE\',0,0
 

--- a/Finite_element_analysis/lesson3.rst
+++ b/Finite_element_analysis/lesson3.rst
@@ -1,3 +1,8 @@
+.. Disable inline anyscript highlighting for double  backticks
+   Specific highlighting can be done with :anyscript:`AnySeg`
+
+.. highlight:: none
+
 Lesson 3: Abaqus Interface
 ==========================
 
@@ -236,7 +241,9 @@ below the study folder:
 
 This will enter an operation called ' ConvertToAbq' into the model and
 running this will execute the AnyFE converter. From the shell prompt you
-write the following to get the same result: ::
+write the following to get the same result: 
+
+.. code-block:: none
 
     AnyFE2Abq.exe -i ..\files_in\clavload.xml -o ..\files_out\output.inp -m .\clavicula.inp
 
@@ -258,7 +265,9 @@ reference frame, even the global system in AnyBody
 the AnyFE XML file may or may not contain motion of the bone and it will
 probably.not be aligned with the FE mesh/CT/MRI scan system. If you
 chose this an option, the AnyFE Converter can remove the rigid body
-motion by using the ``–r`` option equal to 'segment':::
+motion by using the ``–r`` option equal to 'segment':
+
+.. code-block:: none
 
     AnyFE2Abq.exe -i ..\files_in\clavload.xml -o ..\files_out\output.inp -m .\clavicula.inp –r segment
 
@@ -270,7 +279,9 @@ If the reference frame of the segment is not identical to the one of the
 FE mesh, one can apply a constant transformation to all data
 accommodating for this misalignment. The ``–t`` option allows you to
 enter the transformation as a string containing space separated numbers.
-The command line will look like:::
+The command line will look like:
+
+.. code-block:: none
 
     AnyFE2Abq.exe -i ..\files_in\clavload.xml -o ..\files_out\output.inp -m .\clavicula.inp –r segment –t "a11 a12 a13 a21 a22 a23 a31 a32 a33 dx dy dz"
 

--- a/ForceDependentKinematics/lesson1.rst
+++ b/ForceDependentKinematics/lesson1.rst
@@ -5,9 +5,10 @@ In this lesson we familiarize ourselves with the simple knee model. If
 you have not already downloaded the model, then please do so from this
 link: :download:`DemoSimpleKnee.any <Downloads/DemoSimpleKnee.any>`. Save the
 model to a working area of your hard disk, for instance in
-``Documents\AnyScripts\tutorials``. Then open the model in AnyBody, expand
+:file:`Documents\AnyScripts\tutorials`. Then open the model in AnyBody, expand
 “Study” in the Operations Tree, select InverseDynamics and click Run.
 This is what the model looks like:
+
 
 |Model view DemoSimpleKnee|
 

--- a/Interface_features/lesson5.rst
+++ b/Interface_features/lesson5.rst
@@ -28,8 +28,7 @@ We need a model to work on, so please download and save
 1. Launch the command prompt, change directory to where you have saved
    Demo.outputfile.any
 
-2. Run the .exe file using its full path, e.g. **"C:\\Program
-   Files\\AnyBody Technology\\AnyBody.7.0\\AnyBodyCon.exe"**.
+2. Run the .exe file using its full path, e.g. ``"C:\Program Files\AnyBody Technology\AnyBody.7.0\AnyBodyCon.exe"``.
 
 Console commands
 ----------------
@@ -40,7 +39,7 @@ The table below contains a description of the commands accepted by the
 AnyBody console.
 
 +-----------------------+----------------------------------------------------------------------------------------------+
-| **Command name **     | **Functionality**                                                                            |
+| **Command name**      | **Functionality**                                                                            |
 +=======================+==============================================================================================+
 | load "filename.any"   | Example: load "demo.outputfile.any"                                                          |
 |                       |                                                                                              |
@@ -83,7 +82,9 @@ Using the console application
 -----------------------------
 
 Start AnyBodyCon.exe from the command prompt and issue the command
-sequence::
+sequence
+
+.. code-block:: none
 
     load "demo.outputfile.any"
     operation Main.ArmStudy.InverseDynamics
@@ -151,7 +152,9 @@ corresponds to the variables defined in the AnyOutputFile command.
 You can also save the output when using the GUI version by
 right-clicking on the Output subfolder of the Study folder in the Model
 Tree and choosing “Save Data”. We can replicate this in the console as
-follows::
+follows
+
+.. code-block:: none
 
     load "demo.outputfile.any"
     operation Main.ArmStudy.InverseDynamics
@@ -196,11 +199,15 @@ change the number of time steps in our operation.
     
 
 
-If we now exchange::
+If we now exchange
+
+.. code-block:: none
 
     load "demo.outputfile.any"
 
-from our operation sequence with::
+from our operation sequence with
+
+.. code-block:: none
 
     load "demo.outputfile.any" –def NOSTEPS=50
 
@@ -267,7 +274,9 @@ first need to modify the AnyScript file with an OUTPUTFILE argument:
 
 
 Further we create an .anymcr file which we can call ‘runarm.anymcr’. It
-contains the following operations::
+contains the following operations
+
+.. code-block:: none
 
     load "demo.outputfile.any"
     operation RunApplication
@@ -278,7 +287,7 @@ We can now execute the macro file by calling
 
 .. code-block:: bat
 
-    C:\\Program Files\\AnyBody Technology\\AnyBody.7.0AnyBodyCon.exe" /m “runarm.anymcr”
+    C:\Program Files\AnyBody Technology\AnyBody.7.0AnyBodyCon.exe" /m “runarm.anymcr”
 
 from the folder where we saved our model and the macro
 file. It will create an output file called ‘armoutput.anydata.h5’ which
@@ -289,9 +298,9 @@ a #define statement for the file name
 
 .. code-block:: bat
 
-    C:\\Program Files\\AnyBody Technology\\AnyBody.7.0\\AnyBodyCon.exe" /m runarm.anymcr /def OUTPUTFILE=---"\\"myoutput.anydata.h5\\""
+    C:\Program Files\AnyBody Technology\AnyBody.7.0\AnyBodyCon.exe" /m runarm.anymcr /def OUTPUTFILE=---"\"myoutput.anydata.h5\""
     
-What the construction ``—“\\” … \\””`` is doing, in this case,
+What the construction :literal:`—“\” … \””` is doing, in this case,
 is that it will define a quoted string for the #define statement similar
 to the definition in the .any file. As a result we see that the output
 is written to the file ‘myoutput.anydata.h5’.
@@ -309,11 +318,11 @@ with a statement such as:
 
 .. code-block:: bat
 
-    path %path%;C:\\Program Files\\AnyBody Technology\\AnyBody.7.0;
+    path %path%;C:\Program Files\AnyBody Technology\AnyBody.7.0;
 
 It will add AnyBodyCon.exe's path to the existing path
-definition. Notice that there cannot be any space between ``;``` and the
-following path ``c:\\...`` and that you can see the resulting path by
+definition. Notice that there cannot be any space between :literal:`;` and the
+following path :literal:`c:\...` and that you can see the resulting path by
 simply calling the internal path command again without arguments.
 
 These statements will only take effect until the current command prompt
@@ -322,8 +331,8 @@ to the path for all command prompts. In Windows XP for instance, you do
 this from Control Panel -> System under the Advanced tab. You should,
 however, be aware that multiple versions of AnyBody may be installed on
 the computer at the same time, and therefore, multiple versions of
-``AnyBodyCon.exe`` may exist in different locations. Thus, your path
-specification not only makes it easy to call ``AnyBodyCon.exe``; it will
+:literal:`AnyBodyCon.exe` may exist in different locations. Thus, your path
+specification not only makes it easy to call :literal:`AnyBodyCon.exe`; it will
 also specify which version that will be used. This can make it unclear
 which version you are actually using if you need several of them.
 

--- a/Making_things_move/lesson1.rst
+++ b/Making_things_move/lesson1.rst
@@ -8,12 +8,13 @@ is its rotational angle away from its resting vertical position. And we
 can very easily drive the pendulum using this DoF.
 
 The simplest mechanism of motion drivers in AnyBody is called
-AnyKinMotion. With Pendulum.any open in an editor and the model loaded,
+``AnyKinMotion`` . With Pendulum.any open in an editor and the model loaded,
 please place the cursor in the editor window just below then ending
-brace of the AnySeg Pendulum definition. Then click the Classes tab on
-the left hand side of the editor window. Unfold the class list and
-scroll down to find AnyKinMotion. Right-click and insert an instance at
+brace of the ``AnySeg Pendulum`` definition. Then click the Classes tab on
+the left-hand side of the editor window. Unfold the class list and
+scroll down to find ``AnyKinMotion`` . Right-click and insert an instance at
 the cursor position:
+
 
 .. code-block:: AnyScriptDoc
 
@@ -38,7 +39,7 @@ the cursor position:
     };§
 
 
-The prototype of the AnyKinMotion class is set up to allow several
+The prototype of the :code:`AnyKinMotion` class is set up to allow several
 different options. But the simplest of these is to directly specify
 something to drive and a function to drive it with. So we start out by
 giving the object a name and removing all of its content.
@@ -100,13 +101,15 @@ If you have a model view open, you should see the pendulum starting to
 move and accelerate as it rotates a little more than one round before
 the end of the analysis at *t* = 1 second.
 
-The use of AnyKinMotion objects to drive a model is in principle always
+The use of :code:`AnyKinMotion` objects to drive a model is in principle always
 like this, but you can select any Kinematic Measure to drive, i.e. not
 just a simple joint angle, and you can use any function derived from the
 abstract AnyParamFun class to drive it with.
 
 In :doc:`lesson 2 <lesson2>` we shall see how this same mechanism
 allows you to drive the pendulum by motion capture data.
+
+
 
 
 .. rst-class:: without-title

--- a/Making_things_move/lesson2.rst
+++ b/Making_things_move/lesson2.rst
@@ -72,11 +72,13 @@ give a name to the object:
 
 
 
-ConstructChartOnOff instructs the C3D object to not draw 3D
+``ConstructChartOnOff`` instructs the C3D object to not draw 3D
 trajectories.
 
 Now, try loading the model again. You may get the following error
 message:
+
+.. code-block:: none
 
     Time, 't', has an invalid value for this interpolation
 
@@ -296,7 +298,9 @@ should get this:
 
 
 Now load the model and run the kinematic analysis. You will get the
-following error message:::
+following error message:
+
+.. code-block:: none
 
     Model is kinematically over-constrained : Position analysis failed : 2 unsolvable constraint(s) found
 

--- a/Making_things_move/lesson4.rst
+++ b/Making_things_move/lesson4.rst
@@ -429,7 +429,9 @@ This opens a file manager dialogue. Please navigate to the directory
 where you keep the model and specify a name for the new file, for
 instance Opt1.txt.
 
-If you open the new file you can see the saved values:::
+If you open the new file you can see the saved values:
+
+.. code-block:: none
 
     Jointx 1.574482553785737e-002
 
@@ -551,7 +553,7 @@ find that the optimization takes much more time, the convergence is much
 less stable, the segment moves far away from the marker nodes in the
 process, and eventually the algorithm gives up with the error message:
 
-::
+.. code-block:: none
 
     Optimization failed : Failed to solve position analysis
 

--- a/Making_things_move/lesson5.rst
+++ b/Making_things_move/lesson5.rst
@@ -10,19 +10,19 @@ which comes with the installation of AnyBody, contains two pre-cooked
 models that are very easy to drive with your own data and which contain
 some really neat features for data processing.
 
-1. Go to the ``Application\Examples`` folder to find a folder called
+1. Go to the :file:`Application\Examples` folder to find a folder called
    MoCapModel.
 
 2. Take a copy of the entire folder and call it something else, for
    instance MyMoCapModel. You may even want to place it in a new
-   directory parallel to Application\\Examples, for instance
-   Application\\MyModels, to avoid polluting the original examples.
+   directory parallel to :file:`Application\Examples`, for instance
+   :file:`Application\MyModels`, to avoid polluting the original examples.
    Please note that you have to put a copy of the libdef.any file into
    the new directory in that case.
 
 3. Browse into the MyMoCapModel folder.
 
-4. Open the file ``MoCap_LowerBody.main.any`` in the AnyBody Modeling
+4. Open the file :file:`MoCap_LowerBody.main.any` in the AnyBody Modeling
    System.
 
 As the name indicates, this is a gait model comprising only the lower
@@ -131,7 +131,9 @@ sometimes slowly and sometimes a bit faster depending on the speed of
 your computer and the progress of the computation. The optimization will
 take a few minutes to complete and it is speeded up significantly if you
 switch the Model View update off during the process. The final message
-you get is: ::
+you get is: 
+
+.. code-block:: none
 
     #### Macro command > classoperation Main.Studies.ParameterIdentification "Save design" --file="GaitNormal0003-processed-OptimizedParametersTest.txt"
     Main.Studies.ParameterIdentification : Saving design...
@@ -262,7 +264,9 @@ posture indicates that this is a person in a hurry.
 Now is the time to run the MotionAndParameterOptimizationSequence. It
 takes a bit of time, and again you can speed up the process by switching
 off the update of the Model View window. Eventually, the process comes
-to an end and you get the message:::
+to an end and you get the message:
+
+.. code-block:: none
 
     Optimization converged
     ********************************************************************

--- a/Muscle_modeling/lesson5.rst
+++ b/Muscle_modeling/lesson5.rst
@@ -769,10 +769,9 @@ If you run it, you will see the model moving as it does when running the
 InverseDynamics operation of the original AnyBodyStudy. But when the
 analysis is done, the following message appears in the message window:
 
-::
+.. code-block:: none
 
-    The tendon length of muscle Main.MyModel.Muscle2 was calibrated. The
-    muscle properties have been updated.
+    The tendon length of muscle Main.MyModel.Muscle2 was calibrated. The muscle properties have been updated.
 
 Try running the InverseDynamics again and plot the Activity of Muscle2.
 You should see the following:

--- a/conf.py
+++ b/conf.py
@@ -21,9 +21,13 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import os
+import sys
 import subprocess
 
 import cloud_sptheme
+
+sys.path.insert(0, os.path.abspath('exts'))
 
 
 try: 
@@ -45,7 +49,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.githubpages',
-
+    #'sphinxcontrib.inlinesyntaxhighlight',
     # 3rd party extensions
     'sphinxcontrib.fulltoc',
 
@@ -54,7 +58,9 @@ extensions = [
     'cloud_sptheme.ext.escaped_samp_literals',
     'cloud_sptheme.ext.issue_tracker',
     'cloud_sptheme.ext.table_styling',
+    'inline_highlight',
 ]
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -110,18 +116,14 @@ exclude_patterns.extend([
 
 
 # The name of the Pygments (syntax highlighting) style to use.
-highlight_language = 'none'
+highlight_language = 'AnyScriptDoc'
 pygments_style = 'AnyScript'
 
-rst_prolog = """
-.. role:: anyscript(code)
-   :language: AnyScriptDoc
-
-.. |AMS_VERSION_X| replace:: 7.1.x
-.. |AMS_VERSION_FULL| replace:: 7.1.0
-.. |AMS_VERSION_SHORT| replace:: 7.1
-
-"""
+# rst_prolog = """
+# .. |AMS_VERSION_X| replace:: 7.1.x
+# .. |AMS_VERSION_FULL| replace:: 7.1.0
+# .. |AMS_VERSION_SHORT| replace:: 7.1
+# """
 
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
@@ -143,7 +145,7 @@ else:
 html_theme_path = [cloud_sptheme.get_theme_dir()]
 
 
-html_title = "%s v%s Documentation" % (project, release)
+html_title = "%s v%s" % (project, release)
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/contributing.rst
+++ b/contributing.rst
@@ -79,9 +79,9 @@ Any block of text is a paragraph. Paragraphs must be separated by one
 or more blank lines. Identation matters in reST, so lines of the same 
 paragraph must be left aligned to the same indentation.
 
-* one asterisk: ``*text*`` for emphasis (italics),
-* two asterisks: ``**text**`` for strong emphasis (boldface), and
-* backquotes: ````text```` for code samples.
+* one asterisk: :literal:`*text*` for emphasis (italics),
+* two asterisks: :literal:`**text**` for strong emphasis (boldface), and
+* backquotes: :literal:` ``text`` ` for code samples.
 
 There are also options for :subscript:`subscript` (``:subscript:`text```) 
 :superscript:`superscript` (``:superscript:`text```) and more.
@@ -143,7 +143,9 @@ The ``AnyScriptDoc`` is highlighter specifically for the documentation in sphinx
 It can highlight AnyScript code even if the syntax is not correct, and any code 
 fenced with **§** is :red:`§marked in red§`.
 
-Here is an example::
+Here is an example
+
+.. code-block:: none
 
     .. code-block:: AnyScriptDoc
 

--- a/exts/inline_highlight.py
+++ b/exts/inline_highlight.py
@@ -1,0 +1,101 @@
+# This extension is based on the sphinxcontrib-inlinesyntaxhighlight
+# By Kay-Uwe (Kiwi) Lorenz
+#
+# https://bitbucket.org/klorenz/sphinxcontrib-inlinesyntaxhighlight/
+#
+# Copyright (c) 2013, Kay-Uwe (Kiwi) Lorenz
+# 
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# 
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL "Kay-Uwe (Kiwi) Lorenz" BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+
+from docutils import nodes
+
+from sphinx.writers.html import HTMLTranslator
+
+DIV_PRE_RE = re.compile(r'^<div[^>]*><pre>')
+PRE_DIV_RE = re.compile(r'\s*</pre></div>\s*$')
+
+
+def html_visit_literal(self, node):
+
+    shall_highlight = False
+
+    has_code_keyword = any(
+        v in [c.lower() for c in node['classes']]
+        for v in ('code', 'anyscript', 'anyscriptdoc')
+    )
+
+    if node.rawsource.startswith('``') or has_code_keyword:
+        lang = self.highlightlang
+        highlight_args = node.get('highlight_args', {})
+
+        # determine if shall_highlight
+        shall_highlight = True
+
+        attrs = node.attributes
+
+        if 'role' in attrs:  # e.g. for :file:`...`
+            shall_highlight = False
+
+        elif 'code' in attrs['classes'] and (attrs.get('language') or lang):
+            shall_highlight = True
+
+        if not lang or lang == 'none':
+            shall_highlight = False
+
+    if shall_highlight:
+        highlighted = self.highlighter.highlight_block(
+            node.astext(), lang, location=node, **highlight_args)
+
+        # highlighted comes as <div class="highlighted"><pre>...</pre></div>
+        highlighted = DIV_PRE_RE.sub('', highlighted)
+        highlighted = PRE_DIV_RE.sub('', highlighted)
+
+        starttag = self.starttag(
+            node, 'code', suffix='',
+            CLASS='docutils literal highlight highlight-%s' % lang
+        )
+        self.body.append(starttag + highlighted + '</code>')
+
+    else:
+        starttag = (
+            self.starttag(node, 'code', suffix='', CLASS='docutils literal') 
+            + '<span class="pre">'
+        )
+        self.body.append(starttag + node.astext() + '</span></code>')
+
+    raise nodes.SkipNode
+
+
+def html_depart_literal(self, node):
+    pass
+
+
+HTMLTranslator.visit_literal = html_visit_literal
+HTMLTranslator.depart_literal = html_depart_literal
+
+
+def setup(app):
+    pass

--- a/exts/inline_highlight.py
+++ b/exts/inline_highlight.py
@@ -41,14 +41,19 @@ PRE_DIV_RE = re.compile(r'\s*</pre></div>\s*$')
 def html_visit_literal(self, node):
 
     shall_highlight = False
-
-    has_code_keyword = any(
+    
+    code_keyword = 'code' in node['classes']
+    anyscript_keyword = any(
         v in [c.lower() for c in node['classes']]
-        for v in ('code', 'anyscript', 'anyscriptdoc')
+        for v in ('anyscript', 'anyscriptdoc')
     )
 
-    if node.rawsource.startswith('``') or has_code_keyword:
-        lang = self.highlightlang
+    if node.rawsource.startswith('``') or code_keyword or anyscript_keyword:
+        if anyscript_keyword:
+            lang = 'AnyScriptDoc'
+        else:
+            lang = self.highlightlang
+
         highlight_args = node.get('highlight_args', {})
 
         # determine if shall_highlight


### PR DESCRIPTION
This ensures that inline AnyScript code fenced with double backtics gets syntax highligted.

E.g.:
```rst
``AnySeg MySeg = {};``
```

AnyScript is used per default, but it can be overridden per document by setting
```rst
.. highlight:: python
```
or disabled with:
```rst
.. highlight:: none
```

When inline highlighting is enabled, normal literal can be done with
```rst
:literal:`this is normal literal text`
```

