### PR TITLE
Add warning about old tutorial

### DIFF
--- a/MuscleRecruitment/Inverse_dynamics.rst
+++ b/MuscleRecruitment/Inverse_dynamics.rst
@@ -1,6 +1,8 @@
 Inverse Dynamics of Muscle Systems
 ==================================
 
+.. include:: /caution_old_tutorial.rst
+
 The AnyBody Modeling System performs inverse dynamics as one of its
 central operations. In biomechanics, inverse dynamics is traditionally
 understood at the process of computing from measured ground reaction

--- a/MuscleRecruitment/index.rst
+++ b/MuscleRecruitment/index.rst
@@ -1,6 +1,8 @@
 Inverse Dynamics of Muscle Systems
 ==================================
 
+.. include:: /caution_old_tutorial.rst
+
 This tutorial introduces what muscle recruitment is and demonstrates the
 different types of recruitment solvers available in the AnyBody Modeling
 System.
@@ -19,4 +21,3 @@ System.
     Lesson 5 <lesson5>
     Lesson 6 <lesson6>
     Lesson 7 <lesson_calibration>
-

--- a/MuscleRecruitment/lesson1.rst
+++ b/MuscleRecruitment/lesson1.rst
@@ -1,6 +1,9 @@
 Lesson 1: The Basics of Muscle Recruitment
 ==========================================
 
+.. include:: /caution_old_tutorial.rst
+
+
 Muscle recruitment in inverse dynamics is the process of determining
 which set of muscle forces will balance a given external load. If we
 take the trouble of setting up the system of equilibrium equations for a

--- a/MuscleRecruitment/lesson2.rst
+++ b/MuscleRecruitment/lesson2.rst
@@ -1,6 +1,9 @@
 Lesson 2: Linear Muscle Recruitment
 ===================================
 
+.. include:: /caution_old_tutorial.rst
+
+
 Let us begin this lesson with a physiological observation. We know that
 there is a metabolic cost involved in development of muscle force. Food
 is a limited resource for living organisms so it is likely that nature

--- a/MuscleRecruitment/lesson3.rst
+++ b/MuscleRecruitment/lesson3.rst
@@ -1,6 +1,8 @@
 Lesson 3: Quadratic Muscle Recruitment
 ======================================
 
+.. include:: /caution_old_tutorial.rst
+
 The simple example of the previous lesson was enough to show us that
 linear muscle recruitment is not going to mimic the physiological
 behavior of living bodies very well. The next logical step would be to

--- a/MuscleRecruitment/lesson4.rst
+++ b/MuscleRecruitment/lesson4.rst
@@ -1,6 +1,8 @@
 Lesson 4: Polynomial Muscle Recruitment
 =======================================
 
+.. include:: /caution_old_tutorial.rst
+
 In the previous two lessons, we learned that linear muscle recruitment
 leads to no muscle synergy at all, while quadratic muscle recruitment
 seems to result in some synergy between the muscles. In general, the

--- a/MuscleRecruitment/lesson5.rst
+++ b/MuscleRecruitment/lesson5.rst
@@ -1,6 +1,8 @@
 Lesson 5: Min/Max Muscle Recruitment
 ====================================
 
+.. include:: /caution_old_tutorial.rst
+
 With the exception of the linear criterion, each of the options
 presented in the previous lessons have produced plausible muscle
 recruitment patterns. We have found that polynomial criteria of

--- a/MuscleRecruitment/lesson6.rst
+++ b/MuscleRecruitment/lesson6.rst
@@ -1,6 +1,8 @@
 Lesson 6: Composite Recruitment Criteria
 ========================================
 
+.. include:: /caution_old_tutorial.rst
+
 So far we have investigated recruitment criteria in the form of
 polynomial sums with degrees ranging from 1 (linear recruitment) to
 infinity (min/max recruitment). It is not given, however, that any

--- a/MuscleRecruitment/lesson_calibration.rst
+++ b/MuscleRecruitment/lesson_calibration.rst
@@ -1,6 +1,8 @@
 Lesson 7: Calibration
 =====================
 
+.. include:: /caution_old_tutorial.rst
+
 One of the challenges in body modeling is that models must be able to
 change size to reflect individuals of different statures. Even if you
 are working on a model of a particular individual, you will almost

--- a/caution_old_tutorial.rst
+++ b/caution_old_tutorial.rst
@@ -1,0 +1,3 @@
+.. rst-class:: without-title
+.. caution:: **Old tutorial:** 
+     This tutorial has not yet been updated to ver. 7 of the AnyBody Modeling System. Some concepts may have changed. 

--- a/conf.py
+++ b/conf.py
@@ -138,7 +138,8 @@ exclude_patterns = ['_build', 'README.rst', 'Thumbs.db', '.DS_Store']
 
 # Exclude the following tutorials
 exclude_patterns.extend([
-    'A_Getting_started_AMMR'
+    'A_Getting_started_AMMR',
+    'caution_old_tutorial.rst'
 ])
 
 


### PR DESCRIPTION
This  adds a warning about the tutorial was made with older version of AMS. 

![image](https://user-images.githubusercontent.com/1038978/32227501-e539471a-be4b-11e7-8591-06bfcc92c2c5.png)


We can remove it once the tutorial have been updated. 