### PR TITLE
Fatal sphinx warnings

### DIFF
--- a/A_Getting_started/intro.rst
+++ b/A_Getting_started/intro.rst
@@ -11,11 +11,11 @@ latest research studies.
 based walking model, cycling etc.) that can serve as a useful learning
 tool, or even as the foundations for your own modeling studies.** 
 
-Building models from the bottom-up is described further in ":doc:`*Getting Started AnyScript Programming* </A_Getting_started_anyscript/intro>`".
+Building models from the bottom-up is described further in ":doc:`Getting Started AnyScript Programming </A_Getting_started_anyscript/intro>`".
 
-Modifying the postures and motion of an existing model is introduced in ":doc:`*Getting Started:
-Modeling* <../A_Getting_started_modeling/intro>`" and the ":doc:`*Making
-Things Move* <../Making_things_move/intro>`" tutorials.
+Modifying the postures and motion of an existing model is introduced in ":doc:`Getting Started:
+Modeling <../A_Getting_started_modeling/intro>`" and the ":doc:`Making
+Things Move <../Making_things_move/intro>`" tutorials.
 
 .. rubric:: Goals for this tutorial
 

--- a/A_Getting_started/lesson1.rst
+++ b/A_Getting_started/lesson1.rst
@@ -34,7 +34,7 @@ supported in the AMMR.
 **Choose the "Human Standing" template and select the
 folder you want to save your new Human Standing model in.** To demonstrate, let us
 save the model in the 'AnyBody.\ |AMS_VERSION_X|\ /AMMR.v\ |AMMR_VERSION|\ -Demo' directory 
-which we extracted in the :doc:`*introduction* <intro>` of this tutorial.
+which we extracted in the :doc:`introduction <intro>` of this tutorial.
 
 Give the model a name, for example :file:`MyStandingHuman`, and press OK to save. 
 

--- a/A_Getting_started/lesson2.rst
+++ b/A_Getting_started/lesson2.rst
@@ -143,8 +143,8 @@ awarded the following message:
 
 You have just completed your first analysis with an AnyBody model. In the
 next lesson, we will examine the effects of posture on the results
-: :doc:`*Lesson 3: Reviewing analysis
-results* <lesson3>`.
+: :doc:`Lesson 3: Reviewing analysis
+results <lesson3>`.
 
 .. |RunApplication| image:: _static/lesson2/image1.png
    

--- a/A_Getting_started/lesson3.rst
+++ b/A_Getting_started/lesson3.rst
@@ -110,8 +110,8 @@ Congratulations! You have just completed your first biomechanical
 analysis with the AnyBody Modeling System. Try changing the posture in the "Mannequin.any" file and investigate the new
 results.
 
-You may also want to check our `*library of previous
-webcasts* <https://www.anybodytech.com/anybody.html?fwd=webcasts>`__  
+You may also want to check our `library of previous
+webcasts <https://www.anybodytech.com/anybody.html?fwd=webcasts>`__  
 for topics of particular interest to you.
 
 .. |Chart view tree| image:: _static/lesson3/image1.png

--- a/A_Getting_started_anyscript/index.rst
+++ b/A_Getting_started_anyscript/index.rst
@@ -10,7 +10,7 @@ be illustrated. A basic “arm” model will be created from scratch, with two
 segments, joints and applied motion and forces.
 
 Once you feel confident with these concepts you should move on to the next
-chapter `*Getting Started with Modelling* <../A_Getting_started_modeling/intro.html>`__ to create a more anatomically realistic
+chapter `Getting Started with Modelling <../A_Getting_started_modeling/intro.html>`__ to create a more anatomically realistic
 model using the full body model in the AMMR.
 
 .. rubric:: Tutorial content

--- a/A_Getting_started_anyscript/lesson1.rst
+++ b/A_Getting_started_anyscript/lesson1.rst
@@ -6,7 +6,7 @@ Lesson 1: Basic Concepts
 
 To create an AnyScript model from scratch, go to "File menu -> New from template…" this will bring up a new window in
 which you choose "Basic Main" and provide a "Target Name" (e.g.,
-*NewModel*) and click OK. This is similar to :ref:`*this step* <model-templates>` from the previous tutorial.
+*NewModel*) and click OK. This is similar to :ref:`this step <model-templates>` from the previous tutorial.
 
 |Editor NewModel.main.any|
 
@@ -49,7 +49,7 @@ organizational folder for containing the entire model you are going to
 build. Let us change the folder name "MyModel" to "ArmModel".
 
 The object named "MyStudy" (of type ``AnyBodyStudy``) is a collection of
-simulation tasks that you want to perform with your model. The :doc:`*Study of Studies* <../A_study_of_studies/intro>` tutorial
+simulation tasks that you want to perform with your model. The :doc:`Study of Studies <../A_study_of_studies/intro>` tutorial
 contains much more information on simulation studies.
 
 .. warning:: Rename "MyStudy" to "ArmModelStudy", and replace all occurences of "MyModel" with "ArmModel". 
@@ -91,7 +91,7 @@ Loading an AnyBody model
 ------------------------
 
 You should be ready to load the model now. If cannot recollect how this is done,
-refer to :ref:`*this section* <loading-a-model>`  from a previous tutorial.
+refer to :ref:`this section <loading-a-model>`  from a previous tutorial.
 
 You may get message similar to the one below, in the Output Window.
 

--- a/A_Getting_started_anyscript/lesson2.rst
+++ b/A_Getting_started_anyscript/lesson2.rst
@@ -2,7 +2,7 @@ Lesson 2: Defining Segments and Displaying Objects
 ==================================================
 
 .. note:: Here's an AnyScript file to start on if you have not completed the previous lesson:
-    :download:`*demo.lesson2.any* <Downloads/demo.lesson2.any>`
+    :download:`demo.lesson2.any <Downloads/demo.lesson2.any>`
 
 The basic building blocks of a mechanical system are the "segments" [#f1]_. In AnyBody,
 the segments are treated as rigid elements which represent human bones as well as non-human components such as exoskeleton/machine parts etc.

--- a/A_Getting_started_anyscript/lesson4.rst
+++ b/A_Getting_started_anyscript/lesson4.rst
@@ -2,7 +2,7 @@ Lesson 4: Imparting movement with Drivers
 =========================================
 
 .. note:: Here's an AnyScript file to start on if you have not completed the
-    previous lesson: :download:`*demo.lesson4.any* <Downloads/demo.lesson4.any>`.
+    previous lesson: :download:`demo.lesson4.any <Downloads/demo.lesson4.any>`.
 
 If you have completed the three previous lessons, you should have a
 model with an upper arm grounded at the shoulder joint and connected to
@@ -75,7 +75,7 @@ But the same driver class could be used to drive translations, for instance a sl
 The following lines assign the shoulder and elbow joint angle measures to the respective drivers.
 Standard AnyBody joints created using classes such as ``AnyRevoluteJoint``, ``AnySphericalJoint`` etc. automatically function as measures.
 More customized measures can be created using classes such as ``AnyKinLinear``, ``AnyKinRotational`` etc. 
-(see :doc:`*this lesson* <../The_mechanical_elements/lesson4>`).:
+(see :doc:`this lesson <../The_mechanical_elements/lesson4>`).:
 
 .. code-block:: AnyScriptDoc
 
@@ -92,7 +92,7 @@ Since the measures constrained by these drivers are angles, the units
 of "DriverPos" and "DriverVel" are radians and radians/sec respectively.
 
 
-Just like in :ref:`*Lesson 3* <reference-objects>`, these lines also
+Just like in :ref:`Lesson 3 <reference-objects>`, these lines also
 use the reference operator ``&`` to point the local variable "Jnt" towards the 
 actual shoulder/elbow joint objects existing in a different folder
 
@@ -113,7 +113,7 @@ warning messages about the lack of kinematic constraints. You're now ready to ge
     that are specific to that study.
 
 **You must now run the "Main.ArmModelStudy.Kinematics" operation. If you need to refer back to how this is done, look at**
-:ref:`*this prior tutorial* <running-analysis>`.
+:ref:`this prior tutorial <running-analysis>`.
 
 
 Since we have no muscles so far, a kinematic analysis is really all that
@@ -157,7 +157,7 @@ Plotting simulation results
 Let us say, you want to plot the position vector of the hand node over the course of movement.
 
 You need to find and plot the variable ".....ForeArm.HandNode.r" in the chart view. If you need help with the chart view,
-refer to :ref:`*this prior tutorial on plotting* <chart-view>`.
+refer to :ref:`this prior tutorial on plotting <chart-view>`.
 
 If you're having trouble finding the correct output variable in the chart view's filtered model tree, refer to the figure below.
 
@@ -165,7 +165,7 @@ If you're having trouble finding the correct output variable in the chart view's
 
 .. rst-class:: without-title
 .. seealso::
-    **Next lesson:** This is the subject of :doc:`*Lesson 5: Definition of muscles and external forces* <lesson5>`.
+    **Next lesson:** This is the subject of :doc:`Lesson 5: Definition of muscles and external forces <lesson5>`.
 
 
 

--- a/A_Getting_started_anyscript/lesson5.rst
+++ b/A_Getting_started_anyscript/lesson5.rst
@@ -18,7 +18,7 @@ Creating a muscle model
 The exact behaviour of muscle tissue is a widely researched (and debated) topic.
 
 AnyBody offers several models of varying sophistication, for modelling muscle behaviour. A detailed introduction 
-to muscle modeling can be found here :doc:`*its own tutorial* <../Muscle_modeling/intro>`. 
+to muscle modeling can be found here :doc:`its own tutorial <../Muscle_modeling/intro>`. 
 
 Here, we will create a very simple muscle model and use it to model our arm model muscles. We start by creating a folder for the muscles:
 
@@ -90,15 +90,15 @@ The physiological behavior of the muscle is defined by the first line:
                AnyMuscleModel &MusMdl = ..Muscles.MusMdl;
 
 
-You can see that it points right back to the muscle model we have already created (:ref:`*Notice the two leading dots* <relative-folder-path>`). Finally, the following line displays the muscle in your model view window:
+You can see that it points right back to the muscle model we have already created (:ref:`Notice the two leading dots <relative-folder-path>`). Finally, the following line displays the muscle in your model view window:
 
 .. code-block:: AnyScriptDoc
 
                AnyDrawMuscle DrwMus = {};
 
 Upon re-loading the model, you should see a thick, red line connecting the muscle's origin and
-insertion points. There are other ways to visualize muscles, and these are described here in a :doc:`*dedicated muscle
-tutorial* <../Muscle_modeling/intro>`.
+insertion points. There are other ways to visualize muscles, and these are described here in a :doc:`dedicated muscle
+tutorial <../Muscle_modeling/intro>`.
 
 The muscle path may appear strange because the mechanism hasn't been assembled by a kinematic analysis. 
 
@@ -186,7 +186,7 @@ Your model (in the image above) doesn't appear to be connected properly at the e
 joint constraints during a simulation.
 
 Use the operation drop down menu to run the "InitialConditions" operation. If you don't remember
-how this is done, refer to :ref:`*this prior tutorial* <running-analysis>`.
+how this is done, refer to :ref:`this prior tutorial <running-analysis>`.
 
 The assembled model should resemble the following figure.
 
@@ -250,7 +250,7 @@ The InverseDynamicAnalysis and plotting muscle forces
 Run the the **InverseDynamicAnalysis** operation from the operations drop-down menu.
 In this analysis, the AnyBody system computes all muscle, joint forces and much more.
 
-Review the instructions from :ref:`*this prior tutorial* <chart-view>` on plotting simulation results. 
+Review the instructions from :ref:`this prior tutorial <chart-view>` on plotting simulation results. 
 
 To plot the muscle forces in the brachialis muscle, open 
 "Main.Study.Output.Model.Muscles.Brachialis" in the chart view's model tree, and plot the variable named ``Fm``.
@@ -310,14 +310,14 @@ development is also different. It now reaches a maximum during the
 movement and drops off again.
 
 .. note:: Applied forces do not have to be constant. They can change with time
-    and other properties in the model.  Please refer to the :doc:`*tutorial on
-    forces* <../The_mechanical_elements/intro>` for more
+    and other properties in the model.  Please refer to the :doc:`tutorial on
+    forces <../The_mechanical_elements/intro>` for more
     details.
 
 **The model you've built here here was anatomically simplified, and it can be a
 difficult job to define a realistic body model from scratch. We recommend that users
-start out with the body models available in the** `*AnyBody Managed Model
-Repository* <http://www.anybodytech.com/anybody.html?fwd=modelrepository>`__.
+start out with the body models available in the** `AnyBody Managed Model
+Repository <http://www.anybodytech.com/anybody.html?fwd=modelrepository>`__.
 
 
 .. rst-class:: without-title

--- a/A_Getting_started_anyscript/lesson6.rst
+++ b/A_Getting_started_anyscript/lesson6.rst
@@ -2,7 +2,7 @@ Lesson 6: Adding Real Bone Geometries
 =====================================
 
 .. note:: Here's an AnyScript file to start on if you have not completed the
-    previous lesson: :download:`*demo.lesson6.any* <Downloads/demo.lesson6.any>`.
+    previous lesson: :download:`demo.lesson6.any <Downloads/demo.lesson6.any>`.
 
 So far the model graphically resembles a "stick figure representation".
 However realistic bone geometries can improve both aesthetics and
@@ -68,7 +68,7 @@ Relocating your STL object
 ----------------------------
 
 When you attach something to a segment, it is by default positioned
-at the segment's origin which is also its center of mass. (This was discussed earlier :ref:`* over here* <class-inserter>`) 
+at the segment's origin which is also its center of mass. (This was discussed earlier :ref:`over here <class-inserter>`) 
 
 Therfore moving the dumbbell to the hand is as simple as relocating the "DrwSTL" object
 from the "ForeArm" folder to the "PalmNode" subfolder. Cut-paste the entire code for the 
@@ -139,7 +139,7 @@ The RGB property specifies the blend of colors Red, Green, and Blue on a normali
 |ModelView dumbbell3|
 
 This completes the Getting Started with AnyScript tutorial. The final
-result of your efforts is in :download:`*demo.arm2d.any <Downloads/demo.arm2d.any>`.
+result of your efforts is in :download:`demo.arm2d.any <Downloads/demo.arm2d.any>`.
 
 
 .. |oldleg1| image:: _static/lesson6/image1.jpeg

--- a/A_Getting_started_modeling/intro.rst
+++ b/A_Getting_started_modeling/intro.rst
@@ -2,8 +2,8 @@ Introduction: Getting Started with Modeling
 ============================================
 
 Developing accurate models of the human body from scratch is an enormous task.
-It is thus practical to use the models in the `*The AnyBody Managed Model
-Repository* <https://anyscript.org/ammr-doc>`__
+It is thus practical to use the models in the `The AnyBody Managed Model
+Repository <https://anyscript.org/ammr-doc>`__
 as a starting template for a new application.
 
 The following elements of the AnyScript language make such templating easier:
@@ -12,7 +12,7 @@ The following elements of the AnyScript language make such templating easier:
 
 -   Body model parameters - For customizing the default AMMR body models
 
-The AMMR installation folder also contains a library of `*demo applications* <https://anyscript.org/ammr-doc/auto_examples/index.html>`__ 
+The AMMR installation folder also contains a library of `demo applications <https://anyscript.org/ammr-doc/auto_examples/index.html>`__ 
 such as MoCap gait, cycling, leg-press exercises etc. If any of these applications are similar to your end goal, you can copy the 
 application's model files and then modify them as required.
 

--- a/A_Getting_started_modeling/lesson1.rst
+++ b/A_Getting_started_modeling/lesson1.rst
@@ -125,7 +125,7 @@ The "Model" folder comes next this holds information specific to the application
 In this case, this is the pedal model. The "Model" folder is sub-divided into three sub-folders:
 
 - **HumanModel** - This is a local reference to the "Main.HumanModel", located within the "Model" folder. 
-  :ref:`*This section* <reference-objects>` can help you recollect what reference objects are. 
+  :ref:`This section <reference-objects>` can help you recollect what reference objects are. 
 
 - **Environment** - This contains external hardware such as chairs,
   bicycles, tools, or, in the present case, a pedal.

--- a/A_Getting_started_modeling/lesson2.rst
+++ b/A_Getting_started_modeling/lesson2.rst
@@ -8,7 +8,7 @@ body parts: legs, arms, and trunk.
 
 **Body model configuration refers to the selection of limb segments to include, muscle model types,
 scaling algorithms etc. These are done by setting switches known as Body model (BM) parameters. 
-The configuration process is described in greater detail in this** `*document* <https://anyscript.org/ammr-doc/bm_config/index>`__
+The configuration process is described in greater detail in this** `document <https://anyscript.org/ammr-doc/bm_config/index>`__
 
 
 

--- a/A_Getting_started_modeling/lesson3.rst
+++ b/A_Getting_started_modeling/lesson3.rst
@@ -24,7 +24,7 @@ With no environmental constraints defined so far, the human body has the followi
 - 2 DOF of rotation (flexion + eversion) at the ankle
 
 **Total Human + pedal DOFs adds up to 19. In other words, we to need to specify 19 constraints before the model is kinematically determinate.
-We will do this using the concepts of "Measures and Drivers" introduced in** :ref:`*this previous chapter* <measures-and-drivers>`.
+We will do this using the concepts of "Measures and Drivers" introduced in** :ref:`this previous chapter <measures-and-drivers>`.
 
 The following steps specify a total of 19 driver constraints for the model:
 
@@ -53,7 +53,7 @@ The constraint enforced by the default drivers are defined as ‘soft’
 constraints - constraints that be overridden by the 19 'hard constraints' which we will define.
 
 **You can therefore sequentially add the 19 hard drivers on top of the soft default drivers, and deactivate the default
-drivers at the** :ref:`*very end of this lesson* <kinematically-determined>` **. The advantage is that you have a model whose 
+drivers at the** :ref:`very end of this lesson <kinematically-determined>` **. The advantage is that you have a model whose 
 kinematics can be tested at every step along the way.**
 
 Step 1: Fixing the pelvis to ground
@@ -80,7 +80,7 @@ the position of the pelvis in a seat. Here we shall simply attach the
 pelvis to this point by means of a rigid connection.
 
 **Drivers which connect the human and environment are traditionally placed in a folder called
-"ModelEnvironmentConnection" (** :ref:`*explained here* <model-structure>` **), and for historical reasons, it is placed in
+"ModelEnvironmentConnection" (** :ref:`explained here <model-structure>` **), and for historical reasons, it is placed in
 an** ``#include`` **file called "JointsAndDrivers.any". Let’s open this file by
 double-clicking of the following line in the main file**:
 
@@ -127,7 +127,7 @@ frame. "Pelvis" must point to the origin of "PelvisSeg", which you can find in t
 "HumanModel->BodyModel->Trunk->SegmentsLumbar->PelvisSeg".**
 
 To find and insert the absolute paths for these nodes into AnyScript, quickly refer back 
-to :ref:`*this previous section* <absolute-folder-path>`.
+to :ref:`this previous section <absolute-folder-path>`.
 
 You should now have the following:
 
@@ -240,8 +240,8 @@ We will place the drivers enforcing these constraints in the "Drivers" folder wi
 
 Insert a"PelvisThoraxDriver" into the Drivers folder, created using the ``AnyKinEqSimpleDriver`` class. 
 You already know how to create model objects from scratch by using the 
-the "Class Inserter" (:ref:`*described here* <class-inserter>`). More details on properties
-such as DriverPos, DriverVel etc. can be (:ref:`*found here* <anykineqsimpledriver>`) :
+the "Class Inserter" (:ref:`described here <class-inserter>`). More details on properties
+such as DriverPos, DriverVel etc. can be (:ref:`found here <anykineqsimpledriver>`) :
 
 .. code-block:: AnyScriptDoc
 
@@ -363,7 +363,7 @@ out of the ground (a spherical joint connection, like in Step 4). You can still 
 You will now constrain this medio-lateral knee movement in your model.
 
 This is done using an ``AnyKinLinear`` measure and a ``AnyKinEqSimpleDriver`` driver acting on that measure
-(:ref:`*read more one measures & drivers here* <measures-and-drivers>`):
+(:ref:`read more one measures & drivers here <measures-and-drivers>`):
 
 .. code-block:: AnyScriptDoc
 
@@ -406,7 +406,7 @@ Step 7: Specify pedal movement
 -------------------------------
 
 We will specify motion for the pedal's hinge joint again using the ``AnyKinEqSimpleDriver``.
-This resembles what you did in :ref:`*this earlier chapter* <anykineqsimpledriver>`.
+This resembles what you did in :ref:`this earlier chapter <anykineqsimpledriver>`.
 
 .. code-block:: AnyScriptDoc
 
@@ -444,7 +444,7 @@ longer complains about the model being kinematically indeterminate.**
 Running kinematics
 ------------------
 
-Select and run the ‘Main.Study.Kinematics’ operation from the operations dropdown menu (:ref:`*more info here* <running-analysis>`). 
+Select and run the ‘Main.Study.Kinematics’ operation from the operations dropdown menu (:ref:`more info here <running-analysis>`). 
 This will show you the movement of the entire system as the pedal is rotating.
 
 |Operation Result Kinematics|
@@ -487,7 +487,7 @@ because the system is over-constrained.**
 However our AnyBody model seems to work despite this constraint redundancy. Why?
 
 This is because, these 150 - 132 = 18 "extra" constraints were also "soft" constraints enforced by the 
-“default mannequin drivers” described :ref:`*here earlier* <mannequin-drivers>`.
+“default mannequin drivers” described :ref:`here earlier <mannequin-drivers>`.
 
 The "DefaultMannequinDrivers" can be found in a subfolder of the “HumanModel” folder, as shown in the figure below.
 These drivers control the human model's posture based on the values in the "Mannequin.any" file.

--- a/A_Getting_started_modeling/lesson4.rst
+++ b/A_Getting_started_modeling/lesson4.rst
@@ -56,7 +56,7 @@ no spring. The minus sign in the expression means that the spring will always op
 Turn off default reaction forces
 --------------------------------
 
-As mentioned in this :ref:`*previous section* <driver-reactions>`, 
+As mentioned in this :ref:`previous section <driver-reactions>`, 
 the "Reaction.Type" property for all kinematic drivers that act on muscle-actuated joints must be set to "Off".
 
 .. code-block:: AnyScriptDoc
@@ -182,7 +182,7 @@ Now, reload the model and run the "RunApplication" operation from the operations
 
 |InverseDynamics_End|
 
-Plot “Main.Study.Output.Model.HumanModel.BodyModel.SelectedOutput.Right.Leg.Muscles.Envelope” (see :ref:`*this for help* <chart-view>`).
+Plot “Main.Study.Output.Model.HumanModel.BodyModel.SelectedOutput.Right.Leg.Muscles.Envelope” (see :ref:`this for help <chart-view>`).
 It expresses the maximum muscle activation level seen across all the muscles
 in the right leg at a given instant:
 

--- a/A_study_of_studies/lesson1.rst
+++ b/A_study_of_studies/lesson1.rst
@@ -88,8 +88,8 @@ AnyBody allows for the definition of joints that only provide kinematic
 constraints but not the associated reaction forces. In fact, the system
 also allows the opposite: Reaction forces without kinematic constraints.
 For an in-depth discussion of some of these issues, please refer to the
-:doc:`*tutorial on mechanical
-elements* <../The_mechanical_elements/intro>`. For now, the
+:doc:`tutorial on mechanical
+elements <../The_mechanical_elements/intro>`. For now, the
 bottom line is that counting reactions can sometimes be tricky, and the
 Mechanical System Information in Object Description is helpful in this
 respect.

--- a/A_study_of_studies/lesson2.rst
+++ b/A_study_of_studies/lesson2.rst
@@ -66,8 +66,8 @@ is used for positioning muscles wrapping over surfaces. It is just not
 visible in this simple model.
 
 The InitialConditions study can be thought of as the first step of a
-kinematic analysis, which will be the subject of :doc:`*the next
-lesson.* <lesson3>`
+kinematic analysis, which will be the subject of :doc:`the next
+lesson. <lesson3>`
 
 
 .. rst-class:: without-title

--- a/A_study_of_studies/lesson3.rst
+++ b/A_study_of_studies/lesson3.rst
@@ -103,12 +103,12 @@ Running kinematic analysis
 Now that you know the basics of kinematic analysis, let us look at how
 it is performed. We need an example to work on, and this one will serve
 the purpose:
-:download:`*demo.SliderCrank3D.any* <Downloads/Demo.SliderCrank3D.any>`
+:download:`demo.SliderCrank3D.any <Downloads/Demo.SliderCrank3D.any>`
 
 |demo.SliderCrank3D.any|
 
-When you load it and open a :doc:`*Model
-View* <../Interface_features/lesson3>` you will see that
+When you load it and open a :doc:`Model
+View <../Interface_features/lesson3>` you will see that
 this is a very simple mechanism comprising only three segments. They are
 not yet connected correctly at their joints, but they will be if you run
 the Kinematics operation. Go to the Study tree, pick Kinematics and
@@ -116,7 +116,7 @@ click the run button. You will see the model assemble and start moving.
 
 The Kinematics operation is precisely an analysis. It assembles data
 when it runs, and you can subsequently investigate those results in the
-:doc:`*ChartFX* <../Interface_features/lesson3>` view. Pick
+:doc:`ChartFX <../Interface_features/lesson3>` view. Pick
 Window -> ChartFX (new) to open it. The kind of results you can get from
 the Kinematics study is everything that has to do with positions,
 velocities, and accelerations. You may expand the tree until you reach
@@ -163,7 +163,7 @@ model grabs something with both hands.
 
 Although the kinematic analysis is useful in its own right for lots of
 purposes, it is also the first step of the InverseDynamics operation,
-the subject of :doc:`*the next lesson* <lesson4>`.
+the subject of :doc:`the next lesson <lesson4>`.
 
 
 .. rst-class:: without-title

--- a/A_study_of_studies/lesson4.rst
+++ b/A_study_of_studies/lesson4.rst
@@ -33,9 +33,9 @@ the dynamic equilibrium equations for a equal amount of unknown forces,
 the so-called reaction forces.
 
 To conclude this tutorial, please try InverseDynamics operations in the
-arm model, :download:`*arm2d.any* <Downloads/arm2d.any>`, and the slider crank
+arm model, :download:`arm2d.any <Downloads/arm2d.any>`, and the slider crank
 mechanism,
-:download:`*demo.SliderCrank3D.any* <Downloads/Demo.SliderCrank3D.any>`. In both
+:download:`demo.SliderCrank3D.any <Downloads/Demo.SliderCrank3D.any>`. In both
 case, you will now see forces being calculated, i.e. forces that a
 non-zero in the output. But please also notice how the slider crank
 study is defined with simpler AnyMechStudy whereas the arm model uses

--- a/Advanced_script_features/lesson2.rst
+++ b/Advanced_script_features/lesson2.rst
@@ -56,13 +56,13 @@ interesting implications:
 The principle of include files in demonstrated in the following four
 interconnected files:
 
--  :download:`*demo.include.any* <Downloads/demo.include.any>` (the main file)
+-  :download:`demo.include.any <Downloads/demo.include.any>` (the main file)
 
--  :download:`*demo.include2.any* <Downloads/demo.include2.any>`
+-  :download:`demo.include2.any <Downloads/demo.include2.any>`
 
--  :download:`*demo.include3.any* <Downloads/demo.include3.any>`
+-  :download:`demo.include3.any <Downloads/demo.include3.any>`
 
--  :download:`*demo.include4.any* <Downloads/demo.include4.any>`
+-  :download:`demo.include4.any <Downloads/demo.include4.any>`
 
 |Include tree|
 

--- a/AnyExp4SOLIDWORKS/lesson3.rst
+++ b/AnyExp4SOLIDWORKS/lesson3.rst
@@ -216,7 +216,7 @@ machine, but because he was not designed to sit on the machine, we need
 to change his position so it is relative to the fitness machine. We do
 this by changing the mannequin of the model. Since we do not want to
 spend too much time positioning the human model in this tutorial, we
-will use the file :download:`*Mannequin.any* <Downloads/Mannequin.any>` (click to download). Copy the file to the Model subfolder
+will use the file :download:`Mannequin.any <Downloads/Mannequin.any>` (click to download). Copy the file to the Model subfolder
 to overwrite it.
 
 When we now load the model and run the Kinematics, we will see that out

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = AnyBodyTutorials
 SOURCEDIR     = .

--- a/Parameter_studies_and_optimization/intro.rst
+++ b/Parameter_studies_and_optimization/intro.rst
@@ -30,7 +30,7 @@ behavior of the model. Some examples of applications are:
 seat height and seat horizontal position.`
 
 This functionality is provided through two complementary
-:doc:`*studies* </A_study_of_studies/intro>`:
+:doc:`studies </A_study_of_studies/intro>`:
 
 The **AnyParamStudy** performs an exhaustive search of the variable
 space computing the model's reaction to every combination of the

--- a/Parameter_studies_and_optimization/lesson1.rst
+++ b/Parameter_studies_and_optimization/lesson1.rst
@@ -22,8 +22,8 @@ OptimBike.zip <Downloads/OptimBike.zip>` and unpack it to some
 pertinent place on your hard disk.
 
 The bicycle model is pretty much the 2DBike that you may know from the
-`*AnyBody Managed Model
-Repository* <https://www.anybodytech.com/anybody.html?fwd=modelrepository>`__.
+`AnyBody Managed Model
+Repository <https://www.anybodytech.com/anybody.html?fwd=modelrepository>`__.
 In fact, the structure of the model is as in the repository, so we have
 maintained the traditional division between the BRep directory
 containing the human body model and the ARep directory containing the

--- a/Posture_and_movement/intro.rst
+++ b/Posture_and_movement/intro.rst
@@ -41,8 +41,8 @@ going to formulate a very simple problem, but the principle applies to
 much more complex models as well.
 
 Understanding this tutorial requires a-priory knowledge of the tutorial
-on :doc:`*Parameter Studies and
-Optimization* </Parameter_studies_and_optimization/intro>`.
+on :doc:`Parameter Studies and
+Optimization </Parameter_studies_and_optimization/intro>`.
 
 Definition of the Problem
 -------------------------
@@ -116,8 +116,8 @@ are going to need such joint muscles for flexion and extension
 respectively for both of the two joints. The red lines below add such
 muscles with realistic joint strengths in Newton-meter. For an
 explanation of the use of the AnyGeneralMuscle class, please refer to
-the :doc:`*muscle modeling
-tutorial* </Muscle_modeling/intro>`.
+the :doc:`muscle modeling
+tutorial </Muscle_modeling/intro>`.
 
 .. code-block:: AnyScriptDoc
 

--- a/The_mechanical_elements/lesson2.rst
+++ b/The_mechanical_elements/lesson2.rst
@@ -38,8 +38,8 @@ are defined, then the system might not be able to resolve the
 constraints and put them in their correct positions. The remedy is to
 define the segments so that their initial positions are not too far away
 from the configuration they will have when the constraints are resolved.
-You can read much more about this subject in the tutorial :doc:`*A study of
-Studies* <../A_study_of_studies/intro>`.
+You can read much more about this subject in the tutorial :doc:`A study of
+Studies <../A_study_of_studies/intro>`.
 
 AnyBody provides you with a variety of ways you can connect segments by
 joints. The class tree reveals the following joint class structure:

--- a/The_mechanical_elements/lesson5.rst
+++ b/The_mechanical_elements/lesson5.rst
@@ -363,9 +363,9 @@ Further studies:
 The following two examples illustrate more of the features of forces in
 AnyBody.
 
-1. :download:`*Demo.Forces.any* <Downloads/Demo.Forces.any>`
+1. :download:`Demo.Forces.any <Downloads/Demo.Forces.any>`
 
-2. :download:`*Demo.AnyForce.any* <Downloads/Demo.AnyForce.any>`
+2. :download:`Demo.AnyForce.any <Downloads/Demo.AnyForce.any>`
 
 The first example is a rather basic application of time-varying forces
 to the aimple arm model. In addition to the subjects covered in the

--- a/Troubleshooting_anyscript/intro.rst
+++ b/Troubleshooting_anyscript/intro.rst
@@ -227,6 +227,6 @@ Run-time errors
 
 Run-time errors occur during analysis of a successfully loaded model.
 Their nature and remedies are completely dependent on the nature of the
-study. Please refer to the tutorial ":doc:`*A study of
-studies* </A_study_of_studies/intro>`" for further
+study. Please refer to the tutorial ":doc:`A study of
+studies </A_study_of_studies/intro>`" for further
 information.

--- a/Validation_of_models/intro.rst
+++ b/Validation_of_models/intro.rst
@@ -56,8 +56,8 @@ of the population?
 Model Data Uncertainties
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-In general, the models in the `*AnyScript Managed Model
-Repository* <http://www.anybodytech.com/anybody.html?fwd=modelrepository>`__
+In general, the models in the `AnyScript Managed Model
+Repository <http://www.anybodytech.com/anybody.html?fwd=modelrepository>`__
 are based on data reported in the literature. They often come from
 studies of one or few subjects or cadavers, and the data has little or
 no statistical significance. You will find the references of the data
@@ -91,8 +91,8 @@ to the model input. Some typical cases are:
    its usual operation interval. A too short tendon will cause a muscle
    to excert passive force and likely cause muscles on the other side of
    the joint to work more than they are supposed to. Please notice that
-   AnyBody has facilities for calibrating tendon lengths. :doc:`*The muscle
-   modeling tutorial* </Muscle_modeling/intro>` has
+   AnyBody has facilities for calibrating tendon lengths. :doc:`The muscle
+   modeling tutorial </Muscle_modeling/intro>` has
    in-depth information about these issues.
 
 Boundary Conditions
@@ -149,8 +149,8 @@ wants to make the best of its resources. The user has some amount of
 control over this criterion, but in its basic form it is a minimum
 fatigue criterion that distributes the loads as evenly as possible
 between the muscles taking their individual strengths into account.
-Please refer to :doc:`*A Study of
-Studies* </A_study_of_studies/intro>` for more detailed
+Please refer to :doc:`A Study of
+Studies </A_study_of_studies/intro>` for more detailed
 information.
 
 So the system basically presumes that the body has the knowledge and the

--- a/make.bat
+++ b/make.bat
@@ -33,7 +33,7 @@ if errorlevel 9009 (
 	exit /b 1
 )
 
-%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% -n %SPHINXOPTS% 
 goto end
 
 :da


### PR DESCRIPTION
This makes sphinx-build warnings fail the online builds. 

The PR also remove nested formatting which doesn't work 

e.g. removes the asterisk in the following:
```
:ref:`*hallo*`
```

@ananth-gopalakrishnan Can you review?