### PR TITLE
Fix ammr-doc links

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,6 @@ jobs:
 
   sphinx-build:
     runs-on: ubuntu-latest
-    needs: [build-official-version]
     steps:
       - uses: actions/checkout@v4
        

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,6 @@ jobs:
 
 
   sphinx-build:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [build-official-version]
     steps:
@@ -73,6 +72,7 @@ jobs:
 
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/master'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: AnyBody/tutorials

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,6 @@ defaults:
 jobs:
 
   build-official-version:
-    if: github.event.inputs.run_deploy
 
     runs-on: ubuntu-latest
 
@@ -44,7 +43,11 @@ jobs:
           make clean
           make html O="-W"
 
+      - name: Check links
+        run: sphinx-build -M linkcheck . _build -W --keep-going -a -q 
+
       - name: Deploy 🚀
+        if: github.event.inputs.run_deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,40 +13,38 @@ on:
         required: false
         default: ""
 
-  
+defaults:
+  run:
+    shell: bash -leo pipefail {0} {0}
+
 
 jobs:
 
   build-official-version:
+    if: github.event.inputs.run_deploy
+
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
     
       - name: Checkout last tagged
-        if: "github.event.inputs.run_deploy"
         run: |
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`);
 
-      - name: Setup conda
-        if: "github.event.inputs.run_deploy"
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Install mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          activate-environment: sphinx
           environment-file: environment.yaml
-          channels: conda-forge
-
+  
       - name: Build last tagged version
-        if: "github.event.inputs.run_deploy"
-        shell: bash -l {0}
         run: |
           make clean
           make html O="-W"
 
       - name: Deploy 🚀
-        if: "github.event.inputs.run_deploy"
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
@@ -56,35 +54,24 @@ jobs:
 
 
   sphinx-build:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     needs: [build-official-version]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+       
+      - name: Install mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          fetch-depth: 0
-            
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          activate-environment: sphinx
           environment-file: environment.yaml
-          channels: conda-forge
-
-      - uses: ammaraskar/sphinx-problem-matcher@master
-        # if: github.ref != 'refs/heads/master'
-            
+    
       - name: Build Documentation
-        shell: bash -l {0}
-        run: |
-          make html O="-W"
+        run:  make html O="-W"
 
       - name: Check links
-        shell: bash -l {0}
-        run: |
-          make linkcheck
+        run: sphinx-build -M linkcheck . _build -W --keep-going -a -q 
 
       - name: Deploy 🚀
-        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/A_Getting_started_AMMR/index.md
+++ b/A_Getting_started_AMMR/index.md
@@ -12,9 +12,9 @@
 The AnyBody Managed Model Repository (AMMR), is an open library of musculoskeletal
 models and examples ready to be used with the AnyBody Modeling System.
 
-The [AMMR documentation](https://anyscript.org/ammr-doc/) is hosted
+The [AMMR documentation](https://anyscript.org/ammr/) is hosted
 separately, and contains a few tutorials and other usefull information. The
-[Creating a Human Model from scratch](https://anyscript.org/ammr-doc/creating_model_from_scratch.html) tutorial is
+[Creating a Human Model from scratch](https://anyscript.org/ammr/creating_model_from_scratch.html) tutorial is
 recommended for new users.
 
 
@@ -22,9 +22,9 @@ recommended for new users.
 ```{rubric} AMMR documentation
 ```
 
-- [Main AMMR documentation](https://anyscript.org/ammr-doc/)
-- [Getting started with the AMMR](https://anyscript.org/ammr-doc/getting_started.html)
-- [Configuring the Body Model](https://anyscript.org/ammr-doc/bm_config/index.html)
+- [Main AMMR documentation](https://anyscript.org/ammr/)
+- [Getting started with the AMMR](https://anyscript.org/ammr/getting_started.html)
+- [Configuring the Body Model](https://anyscript.org/ammr/bm_config/index.html)
 
 ```{rubric} AMMR Tutorials
 ```
@@ -32,8 +32,8 @@ recommended for new users.
 ```{toctree}
 :maxdepth: 1
 
-Creating a Human Model from scratch <https://anyscript.org/ammr-doc/creating_model_from_scratch.html>
-Scaling: Joint to joint scaling <https://anyscript.org/ammr-doc/Scaling/lesson1.html>
-Scaling: External Body Measurements <https://anyscript.org/ammr-doc/Scaling/lesson2.html>
-Scaling: Segmental scaling factors <https://anyscript.org/ammr-doc/Scaling/lesson3.html>
+Creating a Human Model from scratch <https://anyscript.org/ammr/creating_model_from_scratch.html>
+Scaling: Joint to joint scaling <https://anyscript.org/ammr/Scaling/lesson1.html>
+Scaling: External Body Measurements <https://anyscript.org/ammr/Scaling/lesson2.html>
+Scaling: Segmental scaling factors <https://anyscript.org/ammr/Scaling/lesson3.html>
 ```

--- a/A_Getting_started_modeling/intro.md
+++ b/A_Getting_started_modeling/intro.md
@@ -3,7 +3,7 @@
 
 Developing accurate models of the human body from scratch is an enormous task.
 It is thus practical to use the models in the [The AnyBody Managed Model
-Repository](https://anyscript.org/ammr-doc/)
+Repository](https://anyscript.org/ammr/)
 as a starting template for a new application.
 
 The following elements of the AnyScript language make such templating easier:
@@ -11,7 +11,7 @@ The following elements of the AnyScript language make such templating easier:
 - Include files - Which aid templating and sharing model components across different applications
 - Body model parameters - For customizing the default AMMR body models
 
-The AMMR installation folder also contains a library of [demo applications](https://anyscript.org/ammr-doc/auto_examples/index.html)
+The AMMR installation folder also contains a library of [demo applications](https://anyscript.org/ammr/auto_examples/index.html)
 such as MoCap gait, cycling, leg-press exercises etc. If any of these applications are similar to your end goal, you can copy the
 application's model files and then modify them as required.
 

--- a/A_Getting_started_modeling/lesson2.md
+++ b/A_Getting_started_modeling/lesson2.md
@@ -18,7 +18,7 @@ body parts: legs, arms, and trunk.
 :::{note}
 Body model configuration refers to the selection of limb segments to include, muscle model types,
 scaling algorithms etc. These are done by setting switches known as Body model (BM) parameters.
-The configuration process is described in greater detail in this [document](https://anyscript.org/ammr-doc/bm_config/index)
+The configuration process is described in greater detail in this [document](https://anyscript.org/ammr/bm_config/index)
 :::
 
 ## Body model configuration

--- a/conf.py
+++ b/conf.py
@@ -240,7 +240,7 @@ html_theme = "sphinx_book_theme"
 pydata_html_theme_options = {
     # "external_links": [
     #     {
-    #         "url": "https://anyscript.org/ammr-doc/",
+    #         "url": "https://anyscript.org/ammr/",
     #         "name": "AMMR Documentation",
     #     },
     # ],
@@ -419,13 +419,13 @@ if tags.has("offline"):
     # Todo find a way to get intersphinx working for offline builds
     intersphinx_mapping["ammr"] = (
         "../../AMMR/Documentation/",
-        ("../.inv/ammr.inv", "https://anyscript.org/ammr-doc/objects.inv"),
+        ("../.inv/ammr.inv", "https://anyscript.org/ammr/objects.inv"),
     )
 else:
     if tags.has("draft"):
-        intersphinx_mapping["ammr"] = ("https://anyscript.org/ammr-doc/beta/", None)
+        intersphinx_mapping["ammr"] = ("https://anyscript.org/ammr/beta/", None)
     else:
-        intersphinx_mapping["ammr"] = ("https://anyscript.org/ammr-doc/", None)
+        intersphinx_mapping["ammr"] = ("https://anyscript.org/ammr/", None)
 
 
 # -- Options for OpenGraph Ext. ----------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -442,6 +442,8 @@ linkcheck_ignore = [
     "https://doi.org/10.1115/1.4052115",  # asme.org prevents the linkcheck
     "https://dx.doi.org/10.1115/1.4001678",  # asme.org prevents the linkcheck
     "https://dx.doi.org/10.1115/1.4029258",  # asme.org prevents the linkcheck
+    "https://doi.org/10.1080/10255840802459412", # tandfonline sometimes blocks linkcheck
+    "https://doi.org/10.1080/23335432.2014.993706", # tandfonline sometimes blocks linkcheck
     "https://anyscript.org/tutorials/dev/", # The dev sides can sometimes be missing.
 ]
 

--- a/index.md
+++ b/index.md
@@ -94,7 +94,7 @@ Look up the AMMR tutorials if you need help and guides for using the AnyBody Man
 : The wiki has a wealth of information, tips&tricks and FAQs for working with the AnyBody Modeling System.
 
 
-[AMMR documenation](https://anyscript.org/ammr-doc/)
+[AMMR documenation](https://anyscript.org/ammr/)
 : Browse documentation on AMMR models and learn about possible settings
 
 [The AnyBodyTech channel](https://www.youtube.com/user/anybodytech)


### PR DESCRIPTION
AMMR documentation moved form anyscript.org/ammr-doc to anyscript.org/ammr

This PR updates all the links